### PR TITLE
fix Memory Leak cause by Webview

### DIFF
--- a/library/src/main/java/com/thefinestartist/finestwebview/FinestWebViewActivity.java
+++ b/library/src/main/java/com/thefinestartist/finestwebview/FinestWebViewActivity.java
@@ -30,6 +30,7 @@ import android.view.animation.AnimationUtils;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
@@ -281,6 +282,7 @@ public class FinestWebViewActivity extends AppCompatActivity implements AppBarLa
     protected TextView menuCopyLinkTv;
     protected LinearLayout menuOpenWith;
     protected TextView menuOpenWithTv;
+    protected FrameLayout webLayout;
 
     protected void bindViews() {
         coordinatorLayout = (CoordinatorLayout) findViewById(R.id.coordinatorLayout);
@@ -298,7 +300,7 @@ public class FinestWebViewActivity extends AppCompatActivity implements AppBarLa
         more = (ImageButton) findViewById(R.id.more);
 
         swipeRefreshLayout = (SwipeRefreshLayout) findViewById(R.id.swipeRefreshLayout);
-        webView = (WebView) findViewById(R.id.webView);
+
 
         gradient = findViewById(R.id.gradient);
         divider = findViewById(R.id.divider);
@@ -316,6 +318,9 @@ public class FinestWebViewActivity extends AppCompatActivity implements AppBarLa
         menuCopyLinkTv = (TextView) findViewById(R.id.menuCopyLinkTv);
         menuOpenWith = (LinearLayout) findViewById(R.id.menuOpenWith);
         menuOpenWithTv = (TextView) findViewById(R.id.menuOpenWithTv);
+        webLayout=(FrameLayout)findViewById(R.id.webLayout);
+        webView = new WebView(getApplicationContext());
+        webLayout.addView(webView);
     }
 
     protected void layoutViews() {
@@ -882,7 +887,9 @@ public class FinestWebViewActivity extends AppCompatActivity implements AppBarLa
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        if (webView != null)
+        if(webLayout!=null) {
+            webLayout.removeAllViews();
             webView.destroy();
+        }
     }
 }

--- a/library/src/main/res/layout/finest_web_view.xml
+++ b/library/src/main/res/layout/finest_web_view.xml
@@ -17,11 +17,10 @@
         <android.support.v4.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent">
-
-            <WebView
-                android:id="@+id/webView"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+            <FrameLayout
+                android:id="@+id/webLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
 
         </android.support.v4.widget.NestedScrollView>
     </android.support.v4.widget.SwipeRefreshLayout>


### PR DESCRIPTION
```
Hi,I'm using the FinestWebView-Android in my project,and I have to say it's a great library and saved my much time and labour ,thank you!
when i using the library ,i find it will cause Memory leak cause by webview ,and some similar question had   discussed in stackOverflow(http://stackoverflow.com/questions/3130654/memory-leak-in-webview),and can easisy appear by using the LeakCanary
```

(https://corner.squareup.com/2015/05/leak-canary.html)
   I fix the bug,may you accept the pull request.
   I'm a newbie in github,may I had Clearly expressed it.At last thank you again for provide so great library!
