### PR TITLE
Added More Schemes to WebView's URL Loading Override Check

### DIFF
--- a/library/src/main/java/com/thefinestartist/finestwebview/FinestWebViewActivity.java
+++ b/library/src/main/java/com/thefinestartist/finestwebview/FinestWebViewActivity.java
@@ -1009,6 +1009,10 @@ public class FinestWebViewActivity extends AppCompatActivity implements AppBarLa
                 intent.setDataAndType(Uri.parse(url), "video/*");
                 view.getContext().startActivity(intent);
                 return true;
+            } else if (url.startsWith("tel:") || url.startsWith("sms:") || url.startsWith("smsto:") || url.startsWith("mms:") || url.startsWith("mmsto:")) {
+                Intent intent = new Intent(Intent.ACTION_VIEW,Uri.parse(url));
+                view.getContext().startActivity(intent);
+                return true;
             } else {
                 return super.shouldOverrideUrlLoading(view, url);
             }

--- a/library/src/main/java/com/thefinestartist/finestwebview/FinestWebViewActivity.java
+++ b/library/src/main/java/com/thefinestartist/finestwebview/FinestWebViewActivity.java
@@ -1007,10 +1007,12 @@ public class FinestWebViewActivity extends AppCompatActivity implements AppBarLa
             if (url.endsWith(".mp4")) {
                 Intent intent = new Intent(Intent.ACTION_VIEW);
                 intent.setDataAndType(Uri.parse(url), "video/*");
+                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 view.getContext().startActivity(intent);
                 return true;
             } else if (url.startsWith("tel:") || url.startsWith("sms:") || url.startsWith("smsto:") || url.startsWith("mms:") || url.startsWith("mmsto:")) {
-                Intent intent = new Intent(Intent.ACTION_VIEW,Uri.parse(url));
+                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 view.getContext().startActivity(intent);
                 return true;
             } else {


### PR DESCRIPTION
I used this library in one of my projects. The web page I loaded had a "Call Us" button that went to a URL like "tel:+90123123123". I noticed WebView didn't handle that correctly. So I've added more schemes to the check method to provide correct intent handling in more cases. I'm using the library with my modified version at the moment. Should this PR be merged and released, I'll switch to using external dependecy.

Thanks.
