### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/library/src/main/java/com/thefinestartist/finestwebview/FinestWebView.java
+++ b/library/src/main/java/com/thefinestartist/finestwebview/FinestWebView.java
@@ -166,6 +166,20 @@ public class FinestWebView {
         protected String data;
         protected String url;
 
+        public Builder(@NonNull Activity activity) {
+            this.context = activity;
+            Base.initialize(activity);
+        }
+
+        /**
+         * If you use context instead of activity, FinestWebView won't be able to override activity animation.
+         * Try to create builder with Activity if it's possible.
+         */
+        public Builder(@NonNull Context context) {
+            this.context = context;
+            Base.initialize(context);
+        }
+
         public Builder setWebViewListener(WebViewListener listener) {
             listeners.clear();
             listeners.add(listener);
@@ -185,20 +199,6 @@ public class FinestWebView {
         public Builder rtl(boolean rtl) {
             this.rtl = rtl;
             return this;
-        }
-
-        public Builder(@NonNull Activity activity) {
-            this.context = activity;
-            Base.initialize(activity);
-        }
-
-        /**
-         * If you use context instead of activity, FinestWebView won't be able to override activity animation.
-         * Try to create builder with Activity if it's possible.
-         */
-        public Builder(@NonNull Context context) {
-            this.context = context;
-            Base.initialize(context);
         }
 
         public Builder theme(@StyleRes int theme) {

--- a/library/src/main/java/com/thefinestartist/finestwebview/FinestWebViewActivity.java
+++ b/library/src/main/java/com/thefinestartist/finestwebview/FinestWebViewActivity.java
@@ -194,6 +194,44 @@ public class FinestWebViewActivity extends AppCompatActivity implements AppBarLa
     protected String data;
     protected String url;
 
+    protected CoordinatorLayout coordinatorLayout;
+
+    protected AppBarLayout appBar;
+    protected Toolbar toolbar;
+    protected RelativeLayout toolbarLayout;
+
+    protected TextView title;
+    protected TextView urlTv;
+
+    protected AppCompatImageButton close;
+    protected AppCompatImageButton back;
+    protected AppCompatImageButton forward;
+    protected AppCompatImageButton more;
+
+    protected SwipeRefreshLayout swipeRefreshLayout;
+    protected WebView webView;
+
+    protected View gradient;
+    protected View divider;
+    protected ProgressBar progressBar;
+
+    protected RelativeLayout menuLayout;
+    protected ShadowLayout shadowLayout;
+    protected LinearLayout menuBackground;
+
+    protected LinearLayout menuRefresh;
+    protected TextView menuRefreshTv;
+    protected LinearLayout menuFind;
+    protected TextView menuFindTv;
+    protected LinearLayout menuShareVia;
+    protected TextView menuShareViaTv;
+    protected LinearLayout menuCopyLink;
+    protected TextView menuCopyLinkTv;
+    protected LinearLayout menuOpenWith;
+    protected TextView menuOpenWithTv;
+
+    protected FrameLayout webLayout;
+
     protected void getOptions() {
         Intent intent = getIntent();
         if (intent == null)
@@ -358,44 +396,6 @@ public class FinestWebViewActivity extends AppCompatActivity implements AppBarLa
         data = builder.data;
         url = builder.url;
     }
-
-    protected CoordinatorLayout coordinatorLayout;
-
-    protected AppBarLayout appBar;
-    protected Toolbar toolbar;
-    protected RelativeLayout toolbarLayout;
-
-    protected TextView title;
-    protected TextView urlTv;
-
-    protected AppCompatImageButton close;
-    protected AppCompatImageButton back;
-    protected AppCompatImageButton forward;
-    protected AppCompatImageButton more;
-
-    protected SwipeRefreshLayout swipeRefreshLayout;
-    protected WebView webView;
-
-    protected View gradient;
-    protected View divider;
-    protected ProgressBar progressBar;
-
-    protected RelativeLayout menuLayout;
-    protected ShadowLayout shadowLayout;
-    protected LinearLayout menuBackground;
-
-    protected LinearLayout menuRefresh;
-    protected TextView menuRefreshTv;
-    protected LinearLayout menuFind;
-    protected TextView menuFindTv;
-    protected LinearLayout menuShareVia;
-    protected TextView menuShareViaTv;
-    protected LinearLayout menuCopyLink;
-    protected TextView menuCopyLinkTv;
-    protected LinearLayout menuOpenWith;
-    protected TextView menuOpenWithTv;
-
-    protected FrameLayout webLayout;
 
     protected void bindViews() {
         coordinatorLayout = (CoordinatorLayout) findViewById(R.id.coordinatorLayout);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed
