### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/library/src/main/java/com/thefinestartist/finestwebview/FinestWebView.java
+++ b/library/src/main/java/com/thefinestartist/finestwebview/FinestWebView.java
@@ -31,6 +31,8 @@ import java.util.List;
  */
 public class FinestWebView {
 
+    private FinestWebView() {}
+
     public static class Builder implements Serializable {
 
         protected final transient Context context;

--- a/library/src/main/java/com/thefinestartist/finestwebview/helpers/BitmapHelper.java
+++ b/library/src/main/java/com/thefinestartist/finestwebview/helpers/BitmapHelper.java
@@ -9,6 +9,8 @@ import android.support.annotation.ColorInt;
  */
 public class BitmapHelper {
 
+    private BitmapHelper() {}
+
     public static Bitmap getGradientBitmap(int width, int height, @ColorInt int color) {
         Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
 

--- a/library/src/main/java/com/thefinestartist/finestwebview/helpers/ColorHelper.java
+++ b/library/src/main/java/com/thefinestartist/finestwebview/helpers/ColorHelper.java
@@ -7,6 +7,8 @@ import android.graphics.Color;
  */
 public class ColorHelper {
 
+    private ColorHelper() {}
+
     public static int disableColor(int color) {
         int alpha = Color.alpha(color);
         int red = Color.red(color);

--- a/library/src/main/java/com/thefinestartist/finestwebview/helpers/TypefaceHelper.java
+++ b/library/src/main/java/com/thefinestartist/finestwebview/helpers/TypefaceHelper.java
@@ -26,6 +26,8 @@ import android.support.v4.util.SimpleArrayMap;
 */
 public class TypefaceHelper {
 
+    private TypefaceHelper() {}
+
     private static final SimpleArrayMap<String, Typeface> cache = new SimpleArrayMap<>();
 
     public static Typeface get(Context c, String name) {

--- a/library/src/main/java/com/thefinestartist/finestwebview/helpers/UrlParser.java
+++ b/library/src/main/java/com/thefinestartist/finestwebview/helpers/UrlParser.java
@@ -7,6 +7,9 @@ import java.net.URL;
  * Created by Leonardo on 11/23/15.
  */
 public class UrlParser {
+
+    private UrlParser() {}
+
     public static String getHost(String url) {
         try {
             return new URL(url).getHost();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
