### PR TITLE
Update AppCompat and fix VectorDrawables on pre lollipop devices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.novoda:bintray-release:0.3.4'
     }
@@ -33,6 +33,6 @@ ext {
     versionCode = 9
     versionName = '1.2.5'
 
-    supportLibVersion = '23.2.1'
+    supportLibVersion = '23.3.0'
     playLibVersion = '8.4.0'
 }

--- a/library/src/main/java/com/thefinestartist/finestwebview/FinestWebViewActivity.java
+++ b/library/src/main/java/com/thefinestartist/finestwebview/FinestWebViewActivity.java
@@ -850,29 +850,12 @@ public class FinestWebViewActivity extends AppCompatActivity implements AppBarLa
 
         ColorStateList colorStateList = new ColorStateList(states, colors);
 
-        Drawable drawable = ContextCompat.getDrawable(this, drawableRes);
-        if (APILevel.require(21)) {
-            VectorDrawable vectorDrawable = (VectorDrawable) drawable;
-            vectorDrawable.setTintList(colorStateList);
-            icon.setImageDrawable(vectorDrawable);
-        } else {
-            VectorDrawableCompat vectorDrawable = (VectorDrawableCompat) drawable;
-            vectorDrawable.setTintList(colorStateList);
-            icon.setImageDrawable(vectorDrawable);
-        }
+        VectorDrawableCompat drawable = VectorDrawableCompat.create(getResources(), drawableRes, null);
+        if(drawable == null)
+            throw new IllegalArgumentException("Could not parse vector drawable");
 
-//        if (drawable instanceof VectorDrawable) {
-//            VectorDrawable vectorDrawable = (VectorDrawable) drawable;
-//            vectorDrawable.setTintList(colorStateList);
-//            icon.setImageDrawable(vectorDrawable);
-//        } else if (drawable instanceof VectorDrawableCompat) {
-//            VectorDrawableCompat vectorDrawable = (VectorDrawableCompat) drawable;
-//            vectorDrawable.setTintList(colorStateList);
-//            icon.setImageDrawable(vectorDrawable);
-//        } else {
-//            //TODO: Add BitmapUtil to update BitmapDrawable with corresponding color
-//            throw new RuntimeException("Update your gradle setting to 2.0.0 by adding following line:classpath \'com.android.tools.build:gradle:2.0.0\'");
-//        }
+        drawable.setTintList(colorStateList);
+        icon.setImageDrawable(drawable);
     }
 
     @Override


### PR DESCRIPTION
Based on issue #48 this fixes the library on pre lollipop devices with support library 23.3.0
